### PR TITLE
feat: Update kafka and mongo-rs for new provisioner interface

### DIFF
--- a/replicore/mongo/indexes.js
+++ b/replicore/mongo/indexes.js
@@ -4,20 +4,28 @@ db = db.getSiblingDB("replicore");
 // Create indexes if missing.
 //   Unique indexes for data integrity.
 db.actions.createIndex({cluster_id: 1, action_id: 1}, {unique: true});
+db.actions_orchestrator.createIndex({cluster_id: 1, action_id: 1}, {unique: true});
 db.agents.createIndex({cluster_id: 1, host: 1}, {unique: true});
 db.agents_info.createIndex({cluster_id: 1, host: 1}, {unique: true});
+db.cluster_settings.createIndex({cluster_id: 1}, {unique: true});
 db.clusters_meta.createIndex({cluster_id: 1}, {unique: true});
 db.discoveries.createIndex({cluster_id: 1}, {unique: true});
+db.discovery_settings.createIndex({namespace: 1, name: 1}, {unique: true});
+db.namespaces.createIndex({ns_id: 1}, {unique: true});
 db.nodes.createIndex({cluster_id: 1, node_id: 1}, {unique: true});
+db.platforms.createIndex({ns_id: 1, name: 1}, {unique: true});
 db.shards.createIndex({cluster_id: 1, shard_id: 1, node_id: 1}, {unique: true});
 
 //   Indexes for performance reasons.
 db.actions.createIndex({cluster_id: 1, node_id: 1, action_id: 1}, {unique: true});
 db.clusters_meta.createIndex({shards: -1, nodes: -1, cluster_id: 1});
 db.clusters_meta.createIndex({cluster_display_name: 1});
+db.cluster_settings.createIndex({next_orchestrate: 1});
+db.discovery_settings.createIndex({next_run: 1});
 
 //   TTL indexes for cleanup (14 days).
 db.actions.createIndex({finished_ts: 1}, {expireAfterSeconds: 1209600});
+db.actions_orchestrator.createIndex({finished_ts: 1}, {expireAfterSeconds: 1209600});
 
 
 /*** VIEW STORE ***/
@@ -32,11 +40,15 @@ db.actions_history.createIndex({
   timestamp: 1,
   state: 1,
 }, {unique: true});
+db.actions_orchestrator.createIndex({cluster_id: 1, action_id: 1}, {unique: true});
 
 //   Indexes for performance reasons.
 db.actions.createIndex({cluster_id: 1, created_ts: -1});
+db.actions_orchestrator.createIndex({cluster_id: 1, created_ts: -1});
+db.cluster_orchestrate_report.createIndex({cluster_id: 1}, {unique: true});
 
 //   TTL index lasting 14 days.
 db.actions.createIndex({finished_ts: 1}, {expireAfterSeconds: 1209600});
 db.actions_history.createIndex({finished_ts: 1}, {expireAfterSeconds: 1209600});
+db.actions_orchestrator.createIndex({finished_ts: 1}, {expireAfterSeconds: 1209600});
 db.events.createIndex({timestamp: 1}, {expireAfterSeconds: 1209600});

--- a/replidev.yaml
+++ b/replidev.yaml
@@ -1,4 +1,4 @@
 project: playground
 
 # Make nodes available from localhost if Replicante Core is running outside of podman.
-#play_server_agents_address: localhost
+play_server_agents_address: localhost

--- a/stores/kafka/manifest.yaml
+++ b/stores/kafka/manifest.yaml
@@ -1,0 +1,3 @@
+versions:
+  - version: '>= 2'
+    template: 'kafka/*.yaml'

--- a/stores/kafka/node.yaml
+++ b/stores/kafka/node.yaml
@@ -2,15 +2,15 @@ containers:
   - name: kafka
     image: 'wurstmeister/kafka:2.12-2.4.1'
     env:
-      KAFKA_ZOOKEEPER_CONNECT: 'host.containers.internal:2181/kafka/{{ CLUSTER_ID }}'
-      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:{{ HOST_PORT_STORE }}'
-      KAFKA_LISTENERS: 'PLAINTEXT://localhost:{{ HOST_PORT_STORE }}'
+      KAFKA_ZOOKEEPER_CONNECT: 'host.containers.internal:2181/kafka/{{ cluster_id }}'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:{{ "{{" }} HOST_PORT_STORE }}'
+      KAFKA_LISTENERS: 'PLAINTEXT://localhost:{{ "{{" }} HOST_PORT_STORE }}'
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_LOG_FLUSH_SCHEDULER_INTERVAL_MS: 60000
       JMX_PORT: 9999
     mount:
       - type: bind
-        src: '{{ DATA_ROOT }}/db'
+        src: '{{ "{{" }} DATA_ROOT }}/db'
         target: '/kafka'
         relabel: private
 
@@ -19,25 +19,25 @@ containers:
     command:
       - '/run.sh'
     env:
-      CLUSTER_ID: '{{ CLUSTER_ID }}'
+      CLUSTER_ID: '{{ cluster_id }}'
     mount:
       - type: bind
-        src: '{{ CONF_ROOT }}/agent-kafka.yaml'
+        src: '{{ "{{" }} CONF_ROOT }}/agent-kafka.yaml'
         target: '/opt/replicante/agent-kafka.template.yaml'
         relabel: shared
         ro: 'true'
       - type: bind
-        src: '{{ CONF_ROOT }}/run.sh'
+        src: '{{ "{{" }} CONF_ROOT }}/run.sh'
         target: '/run.sh'
         relabel: shared
         ro: 'true'
       - type: bind
-        src: '{{ PKI_ROOT }}'
+        src: '{{ "{{" }} PKI_ROOT }}'
         target: '/tls'
         relabel: shared
         ro: 'true'
       - type: bind
-        src: '{{ DATA_ROOT }}/agent'
+        src: '{{ "{{" }} DATA_ROOT }}/agent'
         target: '/data'
         relabel: private
         uid: 1616

--- a/stores/manifest.yaml
+++ b/stores/manifest.yaml
@@ -1,0 +1,5 @@
+stores:
+  - store: kafka
+    manifest: kafka/manifest.yaml
+  - store: mongo/rs
+    manifest: mongo/rs/manifest.yaml

--- a/stores/mongo/rs/manifest.yaml
+++ b/stores/mongo/rs/manifest.yaml
@@ -1,0 +1,3 @@
+versions:
+  - version: '>= 4.2'
+    template: 'mongo/rs/*.yaml'

--- a/stores/mongo/rs/node.yaml
+++ b/stores/mongo/rs/node.yaml
@@ -1,15 +1,15 @@
 containers:
   - name: mongo
-    image: 'mongo:4.2'
+    image: 'mongo:{{ store_version }}'
     command:
       - 'mongod'
       - '--replSet'
-      - '{{ CLUSTER_ID }}'
+      - '{{ cluster_id }}'
       - '--bind_ip'
       - '0.0.0.0'
     mount:
       - type: bind
-        src: '{{ DATA_ROOT }}/db'
+        src: '{{ "{{" }} DATA_ROOT }}/db'
         target: '/data/db'
         relabel: private
 
@@ -19,22 +19,21 @@ containers:
       - 'replicante-agent-mongodb'
     mount:
       - type: bind
-        src: '{{ CONF_ROOT }}/agent-mongodb.yaml'
+        src: '{{ "{{" }} CONF_ROOT }}/agent-mongodb.yaml'
         target: '/opt/replicante/agent-mongodb.yaml'
         relabel: shared
         ro: 'true'
       - type: bind
-        src: '{{ PKI_ROOT }}'
+        src: '{{ "{{" }} PKI_ROOT }}'
         target: '/tls'
         relabel: shared
         ro: 'true'
       - type: bind
-        src: '{{ DATA_ROOT }}/agent'
+        src: '{{ "{{" }} DATA_ROOT }}/agent'
         target: '/data'
         relabel: private
         uid: 1616
     workdir: '/opt/replicante'
-
 
 ports:
   - host: 0


### PR DESCRIPTION
Update templates for Kafka and MongoDB Replica Set to support the new Replicante Platform based `replidev play server`.

Other data stores previously supported (Zookeeper, MongoDB Sharded) are no longer supported and will need to be re-introduced once changes are made to support dynamic clusters.